### PR TITLE
build: Update phantomjs-prebuilt to 2.1.5 and drop peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,16 +24,12 @@
 
     "main": "Gruntfile.js",
 
-    "engines": {
-        "node": ">=0.8.0"
-    },
-
     "scripts": {
         "test": "grunt test"
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.4"
+        "phantomjs-prebuilt": "2.1.5"
     },
 
     "devDependencies": {
@@ -42,10 +38,6 @@
         "grunt-contrib-nodeunit": "0.4.1",
         "grunt-contrib-clean": "1.0.0",
         "pngjs": "2.2.0"
-    },
-
-    "peerDependencies": {
-        "grunt": "0.4.5"
     },
 
     "keywords": [


### PR DESCRIPTION
Update phantomjs-prebuilt to 2.1.5

Also remove peer dependence since that has been removed in grunt 1.0.0 causing grunt 1.0.0 to fail.

We doint need to support nodejs 0.8 either.
