### PR TITLE
Update url for phantomjs-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/paladox/phantomjs.git#a1b33d9164c7c25671c962c7fc717a34ae4923f4"
+        "phantomjs-prebuilt": "git://github.com/paladox/phantomjs.git#451078586d8975f9039ad3dc529b9862630e2305"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/paladox/phantomjs.git#451078586d8975f9039ad3dc529b9862630e2305"
+        "phantomjs-prebuilt": "git://github.com/paladox/phantomjs.git#03cfb557d1b88d1849c74f5820d692652f22b942"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.5"
+        "phantomjs-prebuilt": "git://github.com/paladox/phantomjs.git#a1b33d9164c7c25671c962c7fc717a34ae4923f4"
     },
 
     "devDependencies": {


### PR DESCRIPTION
Reason why is because we keep hitting the rate limit.

With this we will update to this repo https://github.com/paladox/phantomjs

Which includes a release update but were not using it. I just included a binary which this repo will download from. Thus improving download speeds and not hitting the rate limit.
