### PR TITLE
Add install to script so we can add a command to download phantomjs from a different location

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,8 @@
     "main": "Gruntfile.js",
 
     "scripts": {
+        "install": "npm install phantomjs-prebuilt@2.1.6 --phantomjs_cdnurl=https://github.com/paladox/phantomjs/releases/download/2.1.7",
         "test": "grunt test"
-    },
-
-    "dependencies": {
-        "phantomjs-prebuilt": "2.1.5"
     },
 
     "devDependencies": {


### PR DESCRIPTION
Since we keep hitting the rate limit this update changes the locations of were we get the download from.
