### PR TITLE
dependencies: Update phantomjs-prebuilt to 2.1.6-wmf

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs/commit/46e52fdea1780bdb0c184fe04cbff7d5aa366c03"
+        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#46e52fdea1780bdb0c184fe04cbff7d5aa366c03"
     },
 
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "2.1.6"
+        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs/commit/46e52fdea1780bdb0c184fe04cbff7d5aa366c03"
     },
 
     "devDependencies": {


### PR DESCRIPTION
Using the Wikimedia fork of the version only changes the hosting, but allows us to bypass the rate limiting from the official host that is causing us so many issues in CI production.
