### PR TITLE
Update phantomjs-prebuilt to 2.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     },
 
     "dependencies": {
-        "phantomjs-prebuilt": "git://github.com/wikimedia/phantomjs.git#v2.1.6-wmf"
+        "phantomjs-prebuilt": "2.1.7"
     },
 
     "devDependencies": {


### PR DESCRIPTION
They changed there download location to use the binary from GitHub hosted on there release page. Which means we doint need to customise it now.
